### PR TITLE
[BugFix] Adjust Inventory item layout for large viewports (>1800px)

### DIFF
--- a/zombiemancer.css
+++ b/zombiemancer.css
@@ -500,6 +500,18 @@ div.generator-progress.active > span.percent {
   }
 }
 
+@media screen and (min-width: 1800px) {
+  div.shop div.tabs button {
+    margin-right: 0;
+  }
+  div.start-game button, div.end-level button, div.shop button {
+    padding: 6px 6px;
+  }
+  div.level-select {
+    width:60%;
+  }
+}
+
 @media screen and (max-width: 1800px) {
   div.shop div.tabs button {
     margin-right: 0;
@@ -756,15 +768,15 @@ div.skeleton > div.lvl.dead {
   width: 20%;
 }
 .inventory .equipped {
-  width: 40%;
+  width: 30%;
 }
 .inventory .items {
-  width:40%;
+  width: 50%;
 }
 
 .inventory .item {
-  width:4em;
-  height:4em;
+  width:3.5em;
+  height:3.5em;
   border:1px solid white;
   margin: 0.5em;
   position: relative;


### PR DESCRIPTION
### Summary

The inventory items were displayed with less space after the gear sets feature was added. On viewports wider than 1800px, the number of items per row was also reduced.

---
### Changes

- Adjusted item layout in the Inventory for viewports larger than 1800px to restore intended spacing and row count or better.
<img width="1744" height="741" alt="image" src="https://github.com/user-attachments/assets/158226c9-72d5-4e66-a1d3-1c76f070615c" />



