### PR TITLE
[BugFix] Update Skeleton menu text for prestige points per kill

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5323,6 +5323,7 @@ var Incremancer;
             xpPercent: () => Math.round(100 * Math.min(1, c.skeleton().xp / i.xpForNextLevel())),
             xpForNextLevel: () => i.xpForNextLevel(),
             xpRate: () => 100 * i.persistent.xpRate,
+            prestigePointsPerKill: () => (1.00025 ** c.skeleton().level) * c.skeleton().level,
             isAlive: () => i.isAlive(),
             timer: () => Math.ceil(i.skeletonTimer()),
             updateEquippedItems() {

--- a/templates/championshold.html
+++ b/templates/championshold.html
@@ -115,7 +115,7 @@
         </div>
       </div>
       <p>Level: {{zm.skeleton().level}} - {{zm.skeleton().xp|whole}} / {{zm.skeletonMenu.xpForNextLevel()|whole}} xp ({{zm.skeletonMenu.xpRate()}}% xp rate)<br/>Earn xp by killing humans while the Champion is alive, higher level humans reward more xp</p>
-      <p>Increases zombie health and damage by {{zm.skeleton().level}}%, all resource generation by {{zm.skeleton().level}}%,<br/>and receive {{zm.skeleton().level}} prestige points when the Skeleton Champion lands a killing blow. (20 second cooldown)</p>
+      <p>Increases zombie health and damage by {{zm.skeleton().level}}%, all resource generation by {{zm.skeleton().level}}%,<br/>and receive {{zm.skeletonMenu.prestigePointsPerKill()|whole}} prestige points when the Skeleton Champion lands a killing blow. (20 second cooldown)</p>    
     </div>
   </div>
   <div ng-if="zm.skeletonMenu.tab == 'talents'" class="talents">


### PR DESCRIPTION
### Summary

Update Skeleton menu text for prestige points per kill

---
### Changes

- Added a method to calculate the prestige points per kill
<img width="1898" height="815" alt="image" src="https://github.com/user-attachments/assets/80eed6f9-5bf3-4d06-a163-ab62bdd99291" />


