### PR TITLE
[QoL] Add setting to auto-adjust Harpy limit to maximum

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -294,9 +294,15 @@ var Incremancer;
                 }), (function () {
                     ne.getInstance().gameSpeed = 1
                 })), new W(2, "Energy Charge", "5x Energy rate for 20 seconds, cost 50 energy", "", 160, 20, 50, (function () {
-                    ne.getInstance().energySpellMultiplier = 5
+                    ne.getInstance().energySpellMultiplier = 5;
+                    if (ne.getInstance().persistentData.autoMaxHarpies) {
+                       ne.getInstance().setMaxHarpies();
+                    }
                 }), (function () {
-                    ne.getInstance().energySpellMultiplier = 1
+                    ne.getInstance().energySpellMultiplier = 1;
+                    if (ne.getInstance().persistentData.autoMaxHarpies) {
+                       ne.getInstance().setMaxHarpies();
+                    }
                 })), new W(3, "Detonate", "Turns your zombies into fast moving living bombs, cost 69 energy... nice", "", 80, 8, 69, (function () {
                     (new q).zombies.detonate = !0
                 }), (function () {
@@ -1137,6 +1143,7 @@ var Incremancer;
                     trophies: [],
                     vipEscaped: [],
                     autoRelease: !1,
+                    autoMaxHarpies: !1,
                     skeleton: null,
                     skeletonTalents: []
                 }
@@ -1260,6 +1267,10 @@ var Incremancer;
                 brains: this.zombiesInCages,
                 bones: 3 * this.zombiesInCages
             }
+        }
+        setMaxHarpies() {
+            let e = Math.floor(this.getEnergyRate() + this.persistentData.harpies);
+            (e >= 0 && e < this.persistentData.harpies || this.getEnergyRate() >= 1 && e > 0) && (this.persistentData.harpies = e);
         }
         startLevel(e) {
             this.level = e, this.startGame()

--- a/templates/graveyardmenu.html
+++ b/templates/graveyardmenu.html
@@ -43,11 +43,12 @@
       <h4>Harpies <button ng-click="zm.hpinfo = ! zm.hpinfo" class="{{zm.hpinfo ? 'active' : ''}}">Info</button></h4>
       <p ng-show="zm.hpinfo">Release harpies that drop barrels of plague infected zombie flesh on unsuspecting humans. Each harpy consumes 1 energy per second. Harpy bombs infect humans with plague and cause {{zm.model.zombieHealth * 0.2|whole}} damage. The damage scales with zombie health.</p>
       <h4>Energy rate {{zm.model.getEnergyRate()|decimal}} per second</h4>
-      <button ng-click="zm.setHarpies(0);">0</button>
-      <button ng-click="zm.setHarpies(zm.model.persistentData.harpies - 1);">-</button>
+      <button ng-click="zm.setHarpies(0);zm.model.persistentData.autoMaxHarpies = false;">0</button>
+      <button ng-click="zm.setHarpies(zm.model.persistentData.harpies - 1);zm.model.persistentData.autoMaxHarpies = false;">-</button>
       <label>{{zm.model.persistentData.harpies|whole}} harpies</label>
-      <button ng-click="zm.setHarpies(zm.model.persistentData.harpies + 1);">+</button>
-      <button ng-click="zm.setHarpies(zm.maxHarpies());">{{zm.maxHarpies()}}</button>
+      <button ng-click="zm.setHarpies(zm.model.persistentData.harpies + 1);zm.model.persistentData.autoMaxHarpies = false;">+</button>
+      <button ng-click="zm.setHarpies(zm.maxHarpies());zm.model.persistentData.autoMaxHarpies = false;">{{zm.maxHarpies()}}</button>
+      <button ng-click="zm.model.persistentData.autoMaxHarpies = !zm.model.persistentData.autoMaxHarpies" class="{{zm.model.persistentData.autoMaxHarpies ? 'active' : ''}}">Auto Max Harpies</button>
     </div>
     <!-- <div class="bone-collectors bones" ng-if="zm.model.gigazombies">
       <h4>Gigazombies <button ng-click="zm.gzinfo = ! zm.gzinfo" class="{{zm.gzinfo ? 'active' : ''}}">Info</button></h4>


### PR DESCRIPTION


### Summary

Adds a new UI toggle to enable automatic setting of Harpies to their maximum value when the spell "Energy Charge" is cast. The toggle state is saved so the preference persists between sessions.

---
### Changes
- Added toggle control to UI for “Auto Max Harpies”
- Implemented persistence of toggle state across sessions
- Linked toggle behavior to automatically adjust Harpy count when enabled

<img width="996" height="698" alt="image" src="https://github.com/user-attachments/assets/cae75e96-592a-498e-99ed-71f6b842be2e" />



